### PR TITLE
Gravatar fn throws NPE when passed nil as email

### DIFF
--- a/src/clavatar/core.clj
+++ b/src/clavatar/core.clj
@@ -41,7 +41,7 @@
                  rating :pg
                  default :retro}}]
   (let [base-url (str gravatar-base-url
-                      (genhash email)
+                      (genhash (or email ""))
                       ".jpg"
                       (genparams :size size :default default :rating rating))]
     (str (if https "https://secure" "http://www") base-url)))


### PR DESCRIPTION
Since the gravatar function supports default values I suggest supporting nil as email and return the default images.
